### PR TITLE
Only run build workflow on main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: Builds and publishes All relevant objects
 on:
   push:
     branches:
-      - '**'        # matches every branch
+      - 'main'
 
 jobs:
   build:


### PR DESCRIPTION
This workflow builds the artefact and uploads it. It is costly to do this for every branch there is. Since we only plan to deploy from main, we should only be building the commits accepted into the main branch.

There should be another workflow which checks PRs though — something with tests in it. That's for a separate PR.
